### PR TITLE
Fix link case for message-broker-topic documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@ We recommend starting with the Glossary to familiarize yourself with the termino
 Our project uses specific naming conventions for different components. Detailed documentation can be found in the `/naming-conventions` folder:
 
 - [`Id.md`](naming-conventions/Id.md): Explains the naming convention for team IDs, agent profile IDs, and agent instance IDs
-- [`Message-Broker-Topic.md`](naming-conventions/Message-Broker-Topic.md): Outlines the naming convention for message broker topics used in the system
+- [`message-broker-topic.md`](naming-conventions/message-broker-topic.md): Outlines the naming convention for message broker topics used in the system
 
 ## Technical Details
 


### PR DESCRIPTION
The link ref is case sensitive resulting in the link being broken. Updated the reference to be the correct casing to fix the link. I am not sure if any other links are broken, I checked a few and they worked but it might be worth running some testing locally to pickup broken links.