### PR TITLE
feat(installer): bundle Ollama models for offline deployment and outp…

### DIFF
--- a/docs/installation/docker/windows/management/docker-stack-installer.ps1
+++ b/docs/installation/docker/windows/management/docker-stack-installer.ps1
@@ -934,6 +934,41 @@ if ($ConfiguredServices["ollama"]) {
         docker-compose up -d
     }
     Set-Location ..
+
+    # Restore pre-bundled Ollama models if available (offline deployments)
+    $ModelsArchivePath = Join-Path $InstallPath "ollama-models.tar"
+    if (-not (Test-Path $ModelsArchivePath)) {
+        $ModelsArchivePath = Join-Path $InstallPath "archive\ollama-models.tar"
+    }
+    if (Test-Path $ModelsArchivePath) {
+        Write-Host ""
+        Write-Host "Restoring pre-bundled Ollama models..." -ForegroundColor White
+        Write-Host "  This may take several minutes..." -ForegroundColor Gray
+
+        # Wait for Ollama container to be ready before restoring
+        $OllamaReady = $false
+        for ($i = 0; $i -lt 12; $i++) {
+            try {
+                docker exec ollama ollama list 2>&1 | Out-Null
+                if ($LASTEXITCODE -eq 0) { $OllamaReady = $true; break }
+            } catch {}
+            Start-Sleep -Seconds 5
+        }
+
+        if ($OllamaReady) {
+            docker cp $ModelsArchivePath "ollama:/tmp/ollama-models.tar"
+            docker exec ollama sh -c "cd /root/.ollama && tar xf /tmp/ollama-models.tar && rm /tmp/ollama-models.tar"
+            if ($LASTEXITCODE -eq 0) {
+                Write-Host "  [OK] Models restored successfully" -ForegroundColor Green
+                Write-Host "  Available models:" -ForegroundColor White
+                docker exec ollama ollama list
+            } else {
+                Write-Host "  [WARN] Model restore failed - pull models manually after install" -ForegroundColor Yellow
+            }
+        } else {
+            Write-Host "  [WARN] Ollama not ready - pull models manually after install" -ForegroundColor Yellow
+        }
+    }
 } else {
     Write-Host ""
     Write-Host "Skipping Ollama startup (not selected)" -ForegroundColor Yellow
@@ -1656,6 +1691,73 @@ $CredentialsFilePath = Join-Path $InstallPath "CREDENTIALS.txt"
 $CredentialsContent | Out-File -FilePath $CredentialsFilePath -Encoding UTF8
 Write-Host "Credentials file created: CREDENTIALS.txt" -ForegroundColor Green
 Write-Host "Location: $CredentialsFilePath" -ForegroundColor White
+
+# Generate XMPro Variables Table
+Write-Host ""
+Write-Host "Generating XMPro Variables Table..." -ForegroundColor White
+Write-Host "====================================" -ForegroundColor Gray
+
+$XmproVars = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+# MQTT Variables
+if ($ConfiguredServices["mqtt"]) {
+    $mqttPort     = if ($MqttSSLEnabled) { "9003" } else { "9002" }
+    $mqttProtocol = if ($MqttSSLEnabled) { "wss://" } else { "ws://" }
+    $XmproVars.Add([PSCustomObject]@{ CompanyId = ""; Value = $Domain;        VariableName = "mqtt_host" })
+    $XmproVars.Add([PSCustomObject]@{ CompanyId = ""; Value = $MqttPass;      VariableName = "mqtt_password" })
+    $XmproVars.Add([PSCustomObject]@{ CompanyId = ""; Value = $mqttPort;      VariableName = "mqtt_port" })
+    $XmproVars.Add([PSCustomObject]@{ CompanyId = ""; Value = $mqttProtocol;  VariableName = "mqtt_protocol" })
+    $XmproVars.Add([PSCustomObject]@{ CompanyId = ""; Value = $MqttUser;      VariableName = "mqtt_username" })
+    $XmproVars.Add([PSCustomObject]@{ CompanyId = ""; Value = "FALSE";        VariableName = "mqtt_usetsl" })
+}
+
+# Neo4j Variables
+if ($ConfiguredServices["neo4j"]) {
+    $neo4jDbType     = if ($Neo4jSSLEnabled) { "neo4j-https" } else { "neo4j-bolt" }
+    $neo4jUri        = if ($Neo4jSSLEnabled) { "neo4j+s://${Domain}:7687" } else { "neo4j://${Domain}:7687" }
+    $neo4jHttpsUri   = if ($Neo4jSSLEnabled) { "https://${Domain}:7473/db/neo4j/query/v2" } else { "http://${Domain}:7474/db/neo4j/query/v2" }
+    $neo4jHttpsCreds = "${Neo4jUser}:${Neo4jPass}"
+    $XmproVars.Add([PSCustomObject]@{ CompanyId = ""; Value = "neo4j";           VariableName = "neo4j_database" })
+    $XmproVars.Add([PSCustomObject]@{ CompanyId = ""; Value = $neo4jDbType;      VariableName = "neo4j_dbtype" })
+    $XmproVars.Add([PSCustomObject]@{ CompanyId = ""; Value = $neo4jHttpsCreds;  VariableName = "neo4j_https_creds" })
+    $XmproVars.Add([PSCustomObject]@{ CompanyId = ""; Value = $neo4jHttpsUri;    VariableName = "neo4j_https_uri" })
+    $XmproVars.Add([PSCustomObject]@{ CompanyId = ""; Value = $Neo4jPass;        VariableName = "neo4j_password" })
+    $XmproVars.Add([PSCustomObject]@{ CompanyId = ""; Value = $neo4jUri;         VariableName = "neo4j_uri" })
+    $XmproVars.Add([PSCustomObject]@{ CompanyId = ""; Value = $Neo4jUser;        VariableName = "neo4j_user" })
+}
+
+# TimescaleDB (SQL) Variables
+if ($ConfiguredServices["timescaledb"]) {
+    $XmproVars.Add([PSCustomObject]@{ CompanyId = ""; Value = $TimescaleDBUser;   VariableName = "SQL Login" })
+    $XmproVars.Add([PSCustomObject]@{ CompanyId = ""; Value = $TimescaleDBPass;   VariableName = "SQL Password" })
+    $XmproVars.Add([PSCustomObject]@{ CompanyId = ""; Value = $Domain.ToUpper();  VariableName = "SQL Server" })
+}
+
+# Milvus (Vector DB) Variables
+if ($ConfiguredServices["milvus"]) {
+    $vectorDbType = if ($MilvusSSLEnabled) { "milvus-https" } else { "milvus" }
+    $vectorDbUrl  = if ($MilvusSSLEnabled) { "https://${Domain}:19531" } else { "http://${Domain}:19531" }
+    $vectorApiKey = "${MilvusUser}:${MilvusPass}"
+    $XmproVars.Add([PSCustomObject]@{ CompanyId = ""; Value = $vectorApiKey;  VariableName = "vector_api_key" })
+    $XmproVars.Add([PSCustomObject]@{ CompanyId = ""; Value = "default";      VariableName = "vector_db_name" })
+    $XmproVars.Add([PSCustomObject]@{ CompanyId = ""; Value = $vectorDbUrl;   VariableName = "vector_db_url" })
+    $XmproVars.Add([PSCustomObject]@{ CompanyId = ""; Value = $vectorDbType;  VariableName = "vectordbtype" })
+}
+
+if ($XmproVars.Count -gt 0) {
+    Write-Host ""
+    Write-Host "XMPro Variables:" -ForegroundColor Cyan
+    $XmproVars | Format-Table -AutoSize
+
+    $XmproVarsPath = Join-Path $InstallPath "XMPRO_VARIABLES.txt"
+    $header = "CompanyId`tValue`tVariableName"
+    $rows   = $XmproVars | ForEach-Object { "$($_.CompanyId)`t$($_.Value)`t$($_.VariableName)" }
+    @($header) + $rows | Out-File -FilePath $XmproVarsPath -Encoding UTF8
+    Write-Host "XMPro Variables saved to: XMPRO_VARIABLES.txt" -ForegroundColor Green
+    Write-Host "Location: $XmproVarsPath" -ForegroundColor White
+} else {
+    Write-Host "No XMPro variable data available - no services were configured." -ForegroundColor Yellow
+}
 
 Write-Host ""
 Write-Host "Installation completed!" -ForegroundColor Green

--- a/docs/installation/docker/windows/prepare-stack.ps1
+++ b/docs/installation/docker/windows/prepare-stack.ps1
@@ -492,7 +492,8 @@ Generated: $(Get-Date -Format "yyyy-MM-dd HH:mm:ss")
                 }
                 
                 # Build argument list properly - combine all into single array
-                $SaveArgs = @("save", "-o", $ImagesArchivePath) + $SuccessfulDownloads
+                # Wrap path in escaped quotes to handle spaces in directory names
+                $SaveArgs = @("save", "-o", "`"$ImagesArchivePath`"") + $SuccessfulDownloads
                 
                 $SaveProcess = Start-Process -FilePath "docker" `
                     -ArgumentList $SaveArgs `
@@ -520,6 +521,78 @@ Generated: $(Get-Date -Format "yyyy-MM-dd HH:mm:ss")
             Write-Host "WARNING: $($FailedDownloads.Count) image(s) failed - will download during install" -ForegroundColor Yellow
         }
         
+        # Pull and bundle Ollama models for offline use
+        Write-Host ""
+        Write-Host "Downloading Ollama models for offline use..." -ForegroundColor White
+        Write-Host "  nomic-embed-text:latest  (~274 MB) - embedding model (required)" -ForegroundColor Gray
+        Write-Host "  llama3.1:8b              (~5 GB)   - recommended chat model" -ForegroundColor Gray
+        Write-Host "  qwen2.5:14b              (~9 GB)   - high-performance chat model" -ForegroundColor Gray
+        Write-Host "  mistral-nemo:12b         (~7 GB)   - alternative chat model" -ForegroundColor Gray
+        Write-Host "  (This will take a while)" -ForegroundColor Gray
+
+        $OllamaModels = @(
+            "nomic-embed-text:latest",
+            "llama3.1:8b",
+            "qwen2.5:14b",
+            "mistral-nemo:12b"
+        )
+
+        $TempVolumeName    = "ollama-model-prep-$(Get-Random)"
+        $TempContainerName = "ollama-model-prep-$(Get-Random)"
+        # Use a temp path without spaces to avoid Docker volume mount issues
+        $TempModelsOutputDir = Join-Path $env:TEMP "ollama-models-out-$(Get-Random)"
+        New-Item -ItemType Directory -Force -Path $TempModelsOutputDir | Out-Null
+
+        try {
+            Write-Host "  Starting temporary Ollama container..." -ForegroundColor Gray
+            docker run -d --name $TempContainerName -v "${TempVolumeName}:/root/.ollama" ollama/ollama:latest 2>&1 | Out-Null
+            Start-Sleep -Seconds 5
+
+            $ModelsPulled = @()
+            foreach ($Model in $OllamaModels) {
+                Write-Host "  Pulling $Model..." -ForegroundColor White
+                docker exec $TempContainerName ollama pull $Model
+                if ($LASTEXITCODE -eq 0) {
+                    Write-Host "  [OK] $Model" -ForegroundColor Green
+                    $ModelsPulled += $Model
+                } else {
+                    Write-Host "  [WARN] Failed to pull $Model - skipping" -ForegroundColor Yellow
+                }
+            }
+
+            if ($ModelsPulled.Count -gt 0) {
+                Write-Host "  Exporting models to archive..." -ForegroundColor White
+                # Export via alpine into temp path (no spaces)
+                docker run --rm `
+                    -v "${TempVolumeName}:/data" `
+                    -v "${TempModelsOutputDir}:/output" `
+                    alpine sh -c "cd /data && tar cf /output/ollama-models.tar ."
+
+                $TempModelsArchive = Join-Path $TempModelsOutputDir "ollama-models.tar"
+                $ModelsArchivePath = Join-Path $OutputPath "ollama-models.tar"
+
+                if (Test-Path $TempModelsArchive) {
+                    Move-Item -Path $TempModelsArchive -Destination $ModelsArchivePath -Force
+                    $ModelsInfo = Get-Item $ModelsArchivePath
+                    $ModelsSizeGB = [math]::Round($ModelsInfo.Length / 1GB, 2)
+                    Write-Host "  [OK] Models archive created: $ModelsSizeGB GB ($($ModelsPulled.Count) models)" -ForegroundColor Green
+                } else {
+                    Write-Host "  [WARN] Models archive not created - models will need to be pulled on target" -ForegroundColor Yellow
+                }
+            } else {
+                Write-Host "  [WARN] No models pulled - skipping models archive" -ForegroundColor Yellow
+            }
+        } catch {
+            Write-Host "  [WARN] Model download failed: $($_.Exception.Message)" -ForegroundColor Yellow
+            Write-Host "  Models will need to be pulled on the target machine" -ForegroundColor Gray
+        } finally {
+            docker rm -f $TempContainerName 2>&1 | Out-Null
+            docker volume rm $TempVolumeName 2>&1 | Out-Null
+            if (Test-Path $TempModelsOutputDir) {
+                Remove-Item $TempModelsOutputDir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+
         # Download Docker Desktop installer
         Write-Host "Downloading Docker Desktop..." -ForegroundColor White
         
@@ -592,6 +665,24 @@ This package was created using **Docker** and contains everything needed for off
         $OfflineInstructions += @"
 
 4. **docker-stack-installer.ps1** - Main installation script (copy separately)
+"@
+
+        $HasModelsArchive = Test-Path (Join-Path $OutputPath "ollama-models.tar")
+        if ($HasModelsArchive) {
+            $ModelsInfo = Get-Item (Join-Path $OutputPath "ollama-models.tar")
+            $ModelsSizeGB = [math]::Round($ModelsInfo.Length / 1GB, 2)
+            $OfflineInstructions += @"
+
+5. **ollama-models.tar** - Pre-downloaded Ollama models ($ModelsSizeGB GB)
+   - ``nomic-embed-text:latest`` - embedding model (required for vector search)
+   - ``llama3.1:8b``             - recommended chat model (good for most hardware)
+   - ``qwen2.5:14b``             - high-performance chat model (needs more RAM/GPU)
+   - ``mistral-nemo:12b``        - alternative chat model
+   - Models are **automatically restored** by the installer - no manual step required
+"@
+        }
+
+        $OfflineInstructions += @"
 
 ## Offline Installation Steps
 
@@ -628,20 +719,39 @@ You should see all the required images listed.
 3. Run the installer (extracts to current directory):
 
 ``````powershell
-.\docker-stack-installer.ps1
+.\docker-stack-installer.ps1 -Domain <HOSTNAME> -EnableSSL
 ``````
+
+Replace ``<HOSTNAME>`` with the target machine's hostname or IP address.
 
 4. The installer will:
    - Extract ``$ZipName`` to the current directory
    - Move the ZIP file to an ``archive/`` folder
    - Configure all services
+   - **Automatically restore Ollama models** from ``ollama-models.tar`` (if Ollama was selected)
 5. Follow the interactive prompts to configure each service
+
+### Step 4: Choose Your Ollama Model (after install)
+
+All three chat models are pre-loaded. Choose based on available hardware:
+
+| Model | VRAM / RAM needed | Speed |
+|---|---|---|
+| ``llama3.1:8b`` | ~8 GB | Fast |
+| ``mistral-nemo:12b`` | ~12 GB | Medium |
+| ``qwen2.5:14b`` | ~14 GB | Slower but more capable |
+
+Verify loaded models:
+``````powershell
+docker exec ollama ollama list
+``````
 
 ---
 Generated: $(Get-Date -Format "yyyy-MM-dd HH:mm:ss")
 Package Type: Offline Deployment
 Images Included: $($SuccessfulDownloads.Count)
 Missing Images: $($FailedDownloads.Count)
+Ollama Models Included: $(if ($HasModelsArchive) { "Yes (nomic-embed-text, llama3.1:8b, qwen2.5:14b, mistral-nemo:12b)" } else { "No - pull manually after install" })
 "@
         
         $OfflineInstructionsPath = Join-Path $OutputPath "OFFLINE-INSTALLATION-INSTRUCTIONS.md"


### PR DESCRIPTION
…ut XMPro variables

- prepare-stack.ps1: pull and archive nomic-embed-text, llama3.1:8b, qwen2.5:14b, and mistral-nemo:12b into ollama-models.tar during offline package creation
- prepare-stack.ps1: update generated OFFLINE-INSTALLATION-INSTRUCTIONS.md to document model archive contents, hardware requirements, and model selection guidance
- docker-stack-installer.ps1: auto-restore ollama-models.tar into running Ollama container after install using docker cp
- docker-stack-installer.ps1: output XMPRO_VARIABLES.txt with plain-text connection variables for MQTT, Neo4j, TimescaleDB, and Milvus on install completion
- Fix docker save failing on paths containing spaces