### PR TITLE
fix(installer): Linux data-dir permissions + stop-script guard for unconfigured services

### DIFF
--- a/docs/installation/docker/linux/management/stop-all-services.sh
+++ b/docs/installation/docker/linux/management/stop-all-services.sh
@@ -131,7 +131,17 @@ for SERVICE in "${SERVICES[@]}"; do
             cd ..
             continue
         fi
-        
+
+        # Skip services that were never configured. The service folders are always present
+        # (copied from src/), but a service is only "installed" once its install.sh writes a
+        # .env. Without it, `docker compose down` fails interpolating mandatory ${VAR:?...}
+        # values (e.g. otel-lgtm's OTEL_INGEST_TOKEN), which would abort this script.
+        if [ ! -f ".env" ]; then
+            print_color "$YELLOW" "$SERVICE not configured (no .env), skipping"
+            cd ..
+            continue
+        fi
+
         # Stop the service (use --profile ssl to also stop SSL nginx containers)
         COMPOSE_CMD="docker-compose --profile ssl"
         if [ "$REMOVE_VOLUMES" = true ]; then

--- a/docs/installation/docker/src/otel-lgtm/management/install.sh
+++ b/docs/installation/docker/src/otel-lgtm/management/install.sh
@@ -165,6 +165,12 @@ for dir in certs nginx collector otel-lgtm-data; do
     fi
 done
 
+# The grafana/otel-lgtm container writes to /data as a non-root user. On Docker Desktop
+# (Windows/Mac) bind-mount ownership is masked, but on native Linux the root-owned host
+# dir blocks writes and the container fails to start. Make it world-writable, matching the
+# convention used by the neo4j/milvus/mqtt service installers.
+chmod -R 777 otel-lgtm-data 2>/dev/null || true
+
 echo ""
 
 # Port configuration

--- a/docs/installation/docker/src/timescaledb/management/install.sh
+++ b/docs/installation/docker/src/timescaledb/management/install.sh
@@ -695,6 +695,15 @@ fi
 # Set proper permissions for data directories
 echo "Setting directory permissions..."
 chmod -R 755 backups 2>/dev/null || true
+# pgAdmin runs as uid 5050 and must own its data dir. On Docker Desktop (Windows/Mac)
+# bind-mount ownership is masked, so this is never an issue there. On native Linux the
+# host dir is root/sudo-owned, pgAdmin cannot write /var/lib/pgadmin, the container never
+# becomes healthy, and `docker compose up` aborts on the pgadmin-nginx service_healthy
+# dependency before the installer finishes. Give uid 5050 ownership (fall back to 777).
+if ! chown -R 5050:5050 timescaledb-data/pgadmin 2>/dev/null; then
+    sudo chown -R 5050:5050 timescaledb-data/pgadmin 2>/dev/null \
+        || chmod -R 777 timescaledb-data/pgadmin 2>/dev/null || true
+fi
 print_color "$GREEN" "Directory permissions configured"
 
 # SSL Certificate setup

--- a/docs/installation/docker/windows/management/stop-all-services.ps1
+++ b/docs/installation/docker/windows/management/stop-all-services.ps1
@@ -34,19 +34,27 @@ if (-not (Test-Path $InstallPath)) {
 
 Set-Location $InstallPath
 
-# Verify expected folders exist
-$ExpectedFolders = @("neo4j", "milvus", "mqtt", "timescaledb", "ollama", "otel-lgtm")
-$MissingFolders = @()
+# Services to stop: folder name -> display name
+$Services = [ordered]@{
+    "neo4j"       = "Neo4j"
+    "milvus"      = "Milvus"
+    "mqtt"        = "MQTT"
+    "timescaledb" = "TimescaleDB"
+    "ollama"      = "Ollama"
+    "otel-lgtm"   = "OTEL LGTM"
+}
 
-foreach ($folder in $ExpectedFolders) {
+# Verify expected folders exist
+$MissingFolders = @()
+foreach ($folder in $Services.Keys) {
     if (-not (Test-Path $folder)) {
         $MissingFolders += $folder
     }
 }
 
-if ($MissingFolders.Count -eq $ExpectedFolders.Count) {
+if ($MissingFolders.Count -eq $Services.Count) {
     Write-Host "No service folders found in: $InstallPath" -ForegroundColor Red
-    Write-Host "Expected folders: $($ExpectedFolders -join ', ')" -ForegroundColor Yellow
+    Write-Host "Expected folders: $($Services.Keys -join ', ')" -ForegroundColor Yellow
     exit 1
 }
 
@@ -78,169 +86,49 @@ Write-Host "====================" -ForegroundColor Gray
 $StoppedServices = @()
 $FailedServices = @()
 
-# Stop Neo4j
-if (Test-Path "neo4j") {
-    Write-Host ""
-    Write-Host "Stopping Neo4j..." -ForegroundColor White
-    Set-Location "neo4j"
-    try {
-        if ($RemoveVolumes) {
-            docker-compose --profile ssl down -v
-        } else {
-            docker-compose --profile ssl down
-        }
-        
-        if ($LASTEXITCODE -eq 0) {
-            Write-Host "Neo4j stopped successfully" -ForegroundColor Green
-            $StoppedServices += "Neo4j"
-        } else {
-            Write-Host "Failed to stop Neo4j (exit code: $LASTEXITCODE)" -ForegroundColor Red
-            $FailedServices += "Neo4j"
-        }
-    } catch {
-        Write-Host "Error stopping Neo4j: $($_.Exception.Message)" -ForegroundColor Red
-        $FailedServices += "Neo4j"
-    }
-    Set-Location ..
-}
+foreach ($folder in $Services.Keys) {
+    $name = $Services[$folder]
 
-# Stop Milvus
-if (Test-Path "milvus") {
-    Write-Host ""
-    Write-Host "Stopping Milvus..." -ForegroundColor White
-    Set-Location "milvus"
-    try {
-        if ($RemoveVolumes) {
-            docker-compose --profile ssl down -v
-        } else {
-            docker-compose --profile ssl down
-        }
-        
-        if ($LASTEXITCODE -eq 0) {
-            Write-Host "Milvus stopped successfully" -ForegroundColor Green
-            $StoppedServices += "Milvus"
-        } else {
-            Write-Host "Failed to stop Milvus (exit code: $LASTEXITCODE)" -ForegroundColor Red
-            $FailedServices += "Milvus"
-        }
-    } catch {
-        Write-Host "Error stopping Milvus: $($_.Exception.Message)" -ForegroundColor Red
-        $FailedServices += "Milvus"
+    if (-not (Test-Path $folder)) {
+        Write-Host "$name directory not found, skipping" -ForegroundColor Yellow
+        continue
     }
-    Set-Location ..
-}
 
-# Stop MQTT
-if (Test-Path "mqtt") {
     Write-Host ""
-    Write-Host "Stopping MQTT..." -ForegroundColor White
-    Set-Location "mqtt"
-    try {
-        if ($RemoveVolumes) {
-            docker-compose --profile ssl down -v
-        } else {
-            docker-compose --profile ssl down
-        }
-        
-        if ($LASTEXITCODE -eq 0) {
-            Write-Host "MQTT stopped successfully" -ForegroundColor Green
-            $StoppedServices += "MQTT"
-        } else {
-            Write-Host "Failed to stop MQTT (exit code: $LASTEXITCODE)" -ForegroundColor Red
-            $FailedServices += "MQTT"
-        }
-    } catch {
-        Write-Host "Error stopping MQTT: $($_.Exception.Message)" -ForegroundColor Red
-        $FailedServices += "MQTT"
-    }
-    Set-Location ..
-}
+    Write-Host "Stopping $name..." -ForegroundColor White
+    Set-Location $folder
 
-# Stop TimescaleDB
-if (Test-Path "timescaledb") {
-    Write-Host ""
-    Write-Host "Stopping TimescaleDB..." -ForegroundColor White
-    Set-Location "timescaledb"
-    try {
-        if ($RemoveVolumes) {
-            docker-compose --profile ssl down -v
-        } else {
-            docker-compose --profile ssl down
-        }
-        
-        if ($LASTEXITCODE -eq 0) {
-            Write-Host "TimescaleDB stopped successfully" -ForegroundColor Green
-            $StoppedServices += "TimescaleDB"
-        } else {
-            Write-Host "Failed to stop TimescaleDB (exit code: $LASTEXITCODE)" -ForegroundColor Red
-            $FailedServices += "TimescaleDB"
-        }
-    } catch {
-        Write-Host "Error stopping TimescaleDB: $($_.Exception.Message)" -ForegroundColor Red
-        $FailedServices += "TimescaleDB"
-    }
-    Set-Location ..
-}
-
-# Stop Ollama
-if (Test-Path "ollama") {
-    Write-Host ""
-    Write-Host "Stopping Ollama..." -ForegroundColor White
-    Set-Location "ollama"
-    try {
-        if ($RemoveVolumes) {
-            docker-compose --profile ssl down -v
-        } else {
-            docker-compose --profile ssl down
-        }
-        
-        if ($LASTEXITCODE -eq 0) {
-            Write-Host "Ollama stopped successfully" -ForegroundColor Green
-            $StoppedServices += "Ollama"
-        } else {
-            Write-Host "Failed to stop Ollama (exit code: $LASTEXITCODE)" -ForegroundColor Red
-            $FailedServices += "Ollama"
-        }
-    } catch {
-        Write-Host "Error stopping Ollama: $($_.Exception.Message)" -ForegroundColor Red
-        $FailedServices += "Ollama"
-    }
-    Set-Location ..
-}
-
-# Stop OTEL LGTM
-if (Test-Path "otel-lgtm") {
-    Write-Host ""
-    Write-Host "Stopping OTEL LGTM..." -ForegroundColor White
-    Set-Location "otel-lgtm"
-    # Skip if never configured. The folder is always present (copied from src/), but a
-    # service is only "installed" once its install writes a .env. Without it, `down`
-    # fails interpolating the mandatory OTEL_INGEST_TOKEN=${...:?} and reports a false
-    # failure, so skip when no .env exists.
+    # Skip services that were never configured. The service folders are always present
+    # (copied from src/), but a service is only "installed" once its install writes a
+    # .env. Without it, `docker-compose down` fails interpolating mandatory ${VAR:?...}
+    # values (e.g. otel-lgtm's OTEL_INGEST_TOKEN) and reports a false failure.
     if (-not (Test-Path ".env")) {
-        Write-Host "OTEL LGTM not configured (no .env), skipping" -ForegroundColor Yellow
+        Write-Host "$name not configured (no .env), skipping" -ForegroundColor Yellow
         Set-Location ..
-    } else {
-        try {
-            if ($RemoveVolumes) {
-                docker-compose --profile ssl down -v
-            } else {
-                docker-compose --profile ssl down
-            }
-
-            if ($LASTEXITCODE -eq 0) {
-                Write-Host "OTEL LGTM stopped successfully" -ForegroundColor Green
-                $StoppedServices += "OTEL LGTM"
-            } else {
-                Write-Host "Failed to stop OTEL LGTM (exit code: $LASTEXITCODE)" -ForegroundColor Red
-                $FailedServices += "OTEL LGTM"
-            }
-        } catch {
-            Write-Host "Error stopping OTEL LGTM: $($_.Exception.Message)" -ForegroundColor Red
-            $FailedServices += "OTEL LGTM"
-        }
-        Set-Location ..
+        continue
     }
+
+    # Stop the service (use --profile ssl to also stop SSL nginx containers)
+    try {
+        if ($RemoveVolumes) {
+            docker-compose --profile ssl down -v
+        } else {
+            docker-compose --profile ssl down
+        }
+
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "$name stopped successfully" -ForegroundColor Green
+            $StoppedServices += $name
+        } else {
+            Write-Host "Failed to stop $name (exit code: $LASTEXITCODE)" -ForegroundColor Red
+            $FailedServices += $name
+        }
+    } catch {
+        Write-Host "Error stopping ${name}: $($_.Exception.Message)" -ForegroundColor Red
+        $FailedServices += $name
+    }
+
+    Set-Location ..
 }
 
 # Summary

--- a/docs/installation/docker/windows/management/stop-all-services.ps1
+++ b/docs/installation/docker/windows/management/stop-all-services.ps1
@@ -213,25 +213,34 @@ if (Test-Path "otel-lgtm") {
     Write-Host ""
     Write-Host "Stopping OTEL LGTM..." -ForegroundColor White
     Set-Location "otel-lgtm"
-    try {
-        if ($RemoveVolumes) {
-            docker-compose --profile ssl down -v
-        } else {
-            docker-compose --profile ssl down
-        }
+    # Skip if never configured. The folder is always present (copied from src/), but a
+    # service is only "installed" once its install writes a .env. Without it, `down`
+    # fails interpolating the mandatory OTEL_INGEST_TOKEN=${...:?} and reports a false
+    # failure, so skip when no .env exists.
+    if (-not (Test-Path ".env")) {
+        Write-Host "OTEL LGTM not configured (no .env), skipping" -ForegroundColor Yellow
+        Set-Location ..
+    } else {
+        try {
+            if ($RemoveVolumes) {
+                docker-compose --profile ssl down -v
+            } else {
+                docker-compose --profile ssl down
+            }
 
-        if ($LASTEXITCODE -eq 0) {
-            Write-Host "OTEL LGTM stopped successfully" -ForegroundColor Green
-            $StoppedServices += "OTEL LGTM"
-        } else {
-            Write-Host "Failed to stop OTEL LGTM (exit code: $LASTEXITCODE)" -ForegroundColor Red
+            if ($LASTEXITCODE -eq 0) {
+                Write-Host "OTEL LGTM stopped successfully" -ForegroundColor Green
+                $StoppedServices += "OTEL LGTM"
+            } else {
+                Write-Host "Failed to stop OTEL LGTM (exit code: $LASTEXITCODE)" -ForegroundColor Red
+                $FailedServices += "OTEL LGTM"
+            }
+        } catch {
+            Write-Host "Error stopping OTEL LGTM: $($_.Exception.Message)" -ForegroundColor Red
             $FailedServices += "OTEL LGTM"
         }
-    } catch {
-        Write-Host "Error stopping OTEL LGTM: $($_.Exception.Message)" -ForegroundColor Red
-        $FailedServices += "OTEL LGTM"
+        Set-Location ..
     }
-    Set-Location ..
 }
 
 # Summary


### PR DESCRIPTION
## Summary

Fixes the Linux Docker-stack installer aborting before it writes `CREDENTIALS.txt`, plus a related stop-script failure. All three are native-Linux issues that Docker Desktop masks on Windows/Mac (its bind-mount layer ignores Linux uid/gid ownership), which is why the same compose files install cleanly on Windows but fail on a headless Ubuntu host.

## Root cause

`docker compose --profile ssl up` gates `pgadmin-nginx` on `pgadmin` being `service_healthy`. On native Linux the pgAdmin data dir is created root-owned, but the `dpage/pgadmin4` container runs as **uid 5050** and can't write `/var/lib/pgadmin` — so pgAdmin never goes healthy, the `up` aborts, and the installer (`set -euo pipefail`) dies before generating `CREDENTIALS.txt`.

## Changes

- **`src/timescaledb/management/install.sh`** — `chown -R 5050:5050 timescaledb-data/pgadmin` (with `sudo` → `chmod 777` fallbacks). Previously only `backups` was chmod'd; the pgAdmin dir was never given correct ownership.
- **`src/otel-lgtm/management/install.sh`** — `chmod -R 777 otel-lgtm-data` (was created with no permission step; the non-root grafana/otel-lgtm container can't write `/data` on native Linux). Matches the neo4j/milvus/mqtt convention.
- **`linux/management/stop-all-services.sh`** — skip services with no `.env`. Service folders are always present (copied from `src/`), but `docker compose down` on an unconfigured service fails interpolating mandatory `${VAR:?...}` values (e.g. otel-lgtm's `OTEL_INGEST_TOKEN`), aborting the stop run under `set -e`.
- **`windows/management/stop-all-services.ps1`** — refactored the six near-identical per-service blocks into one folder→name loop mirroring the Linux script, applying the same "skip when no `.env`" guard to every service (Windows previously had no guard).

Windows installers need no permission changes — Docker Desktop masks bind-mount ownership.

## Test plan

- [ ] On a headless Ubuntu host with Compose v2, run `./docker-stack-installer.sh` selecting TimescaleDB with `--enable-ssl`; verify it runs to completion and writes `CREDENTIALS.txt`.
- [ ] `docker ps` shows `timescaledb-pgadmin` and `timescaledb-pgadmin-nginx` as `(healthy)`.
- [ ] With OTEL LGTM not installed, run `stop-all-services.sh`; verify it prints "OTEL LGTM not configured (no .env), skipping" and exits 0 instead of erroring on `OTEL_INGEST_TOKEN`.
- [ ] `bash -n` passes on the two `.sh` files; the `.ps1` parses without errors.

## Out of scope / known follow-up

- `timescaledb-postgrest-nginx` can report `(unhealthy)`: its health-check hits PostgREST's root `/` over HTTPS, which can return non-2xx depending on anon-role/schema state. Separate issue, still under diagnosis — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)