### PR TITLE
docs: post-install run sheet for Stream/App Designer variables

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -160,3 +160,5 @@ Remember to regularly review and update your agent profiles to ensure they remai
 ## Next Steps
 
 After completing the installation, access the prompt administration page and ensure the system prompts are using the models providers and models you have enabled.
+
+Then follow the [Post-Installation Configuration](installation/post-install-configuration.md) run sheet to create the Stream Designer and App Designer variables that connect the deployed MAGS stream and app to your infrastructure (Neo4j, MQTT, TimescaleDB, vector database, Ollama).

--- a/docs/installation/docker/README.md
+++ b/docs/installation/docker/README.md
@@ -428,6 +428,10 @@ The installer automatically creates a **CREDENTIALS.txt** file containing:
 
 **IMPORTANT: Keep this file secure and do not commit it to version control!**
 
+### Configure XMPro
+
+With the stack running, follow the [Post-Installation Configuration](../post-install-configuration.md) run sheet to create the Stream Designer and App Designer variables that connect the deployed MAGS stream and app to this stack. `CREDENTIALS.txt` supplies every secret value, including the pre-computed `neo4j_neo4j_https` Basic-auth token for App Designer.
+
 ## Troubleshooting
 
 ### Common Issues

--- a/docs/installation/docker/linux/management/docker-stack-installer.sh
+++ b/docs/installation/docker/linux/management/docker-stack-installer.sh
@@ -1012,6 +1012,14 @@ if [ "${CONFIGURED_SERVICES[neo4j]:-false}" = true ]; then
         echo "Username: ${NEO4J_USER:-neo4j}" >> CREDENTIALS.txt
         echo "Password: ${NEO4J_PASS:-check .env file}" >> CREDENTIALS.txt
         echo "" >> CREDENTIALS.txt
+        # Pre-computed Basic-auth token for the App Designer 'neo4j_neo4j_https' variable
+        # (base64 of username:password). Paste this value straight into App Designer.
+        if [ -n "$NEO4J_PASS" ]; then
+            NEO4J_HTTPS_TOKEN=$(printf '%s:%s' "${NEO4J_USER:-neo4j}" "$NEO4J_PASS" | base64 | tr -d '\n')
+            echo "App Designer variable 'neo4j_neo4j_https' (base64 of username:password):" >> CREDENTIALS.txt
+            echo "  $NEO4J_HTTPS_TOKEN" >> CREDENTIALS.txt
+            echo "" >> CREDENTIALS.txt
+        fi
     fi
     
     echo "Access URLs:" >> CREDENTIALS.txt

--- a/docs/installation/docker/windows/management/docker-stack-installer.ps1
+++ b/docs/installation/docker/windows/management/docker-stack-installer.ps1
@@ -1208,6 +1208,17 @@ Username: $Neo4jUser
 Password: $Neo4jPass
 
 "@
+
+        # Pre-computed Basic-auth token for the App Designer 'neo4j_neo4j_https' variable
+        # (base64 of username:password). Paste this value straight into App Designer.
+        if ($Neo4jPass -and $Neo4jPass -ne "(check Neo4j .env file)") {
+            $Neo4jHttpsToken = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes("${Neo4jUser}:${Neo4jPass}"))
+            $CredentialsContent += @"
+App Designer variable 'neo4j_neo4j_https' (base64 of username:password):
+  $Neo4jHttpsToken
+
+"@
+        }
     }
     
     $CredentialsContent += @"

--- a/docs/installation/post-install-configuration.md
+++ b/docs/installation/post-install-configuration.md
@@ -1,0 +1,128 @@
+# Post-Installation Configuration — Stream Designer & App Designer Variables
+
+Once the MAGS infrastructure stack (Neo4j, MQTT, TimescaleDB, the vector database, Ollama, OpenTelemetry) is deployed and healthy, the deployed MAGS **Stream Designer** stream and **App Designer** pages still have no way to reach it. Connection details are supplied through **Variables** you create in XMPro. This run sheet is the "what to do next" step: create each variable, in the right app, with the right value.
+
+> This guide is deployment-agnostic. Wherever it says "from your credentials store", the Docker installer has already written the value to `CREDENTIALS.txt` in the install directory — that is the worked example used throughout.
+
+## Before you start
+
+- [ ] The infrastructure stack is running and reachable from the XMPro host.
+- [ ] You have the generated secrets to hand. For the Docker deployment, open `CREDENTIALS.txt` from the install directory.
+- [ ] XMPro is licensed, and you can open both **Stream Designer** and **App Designer**.
+- [ ] You know the **hostname/address** each XMPro app should use to reach the stack. Below this is written as `<host>`; replace it with your actual host (or the Docker service name / IP). Secure ports assume the SSL-enabled stack.
+
+## How to read this run sheet
+
+- Variables are split into two lists — **create each list in its own app.** Stream Designer and App Designer share the same variables, but each app encrypts values with its **own encryption key**, so a value entered in one app cannot be decrypted by the other. Every variable — including the ones needed by *both* apps — must be entered **separately in each app**; you cannot set it once and have it carry across.
+- **Secure?** = `Yes` means create the variable as a **Secure** variable so its value is masked and not exported in plain text. These map 1:1 to the secrets in your credentials store.
+- Values shown as `<...>` are placeholders — substitute your environment's value.
+
+---
+
+## 1. Stream Designer variables
+
+Create these in **Stream Designer**.
+
+| Key | Value | Secure? |
+|-----|-------|---------|
+| `otel_endpoint` | `http://<host>:4318` (OpenTelemetry collector; omit if not using OTel) | No |
+| `neo4j_database` | `neo4j` | No |
+| `neo4j_uri` | `neo4j+s://<host>:7687` | No |
+| `neo4j_neo4j_username` | `neo4j` | No |
+| `neo4j_neo4j_password` | Neo4j password — from your credentials store | **Yes** |
+| `mags_memory_collection` | `mags_agent_memories` | No |
+| `rag_general` | `rag_general` | No |
+| `mqtt_broker` | `<host>` | No |
+| `mqtt_port` | `1883` | No |
+| `mqtt_usetls` | `FALSE` | No |
+| `mqtt_xmpro_username` | `xmpro` | No |
+| `mqtt_xmpro_password` | MQTT `xmpro` user password — from your credentials store | **Yes** |
+| `ollama_host_url` | `https://<host>:11443` | No |
+| `ollama_embedding_model` | your embedding model name (e.g. `nomic-embed-text`) | No |
+| `ollama_inference_model` | your inference model name | No |
+| `timescaledb_host` | `<host>` | No |
+| `timescaledb_port` | `5432` | No |
+| `timescaledb_database` | `timescaledb` | No |
+| `timescaledb_postgres_username` | `postgres` | No |
+| `timescaledb_postgres_password` | Postgres/TimescaleDB password — from your credentials store | **Yes** |
+| `vector_url` | `https://<host>:19531` | No |
+| `vector_db_name` | `default` | No |
+| `vector_api_key` | vector DB API key — from your credentials store | **Yes** |
+
+---
+
+## 2. App Designer variables
+
+Create these in **App Designer**. Note the values that intentionally differ from Stream Designer (**⚠️** below).
+
+| Key | Value | Secure? |
+|-----|-------|---------|
+| `neo4j_db_type` | `neo4j-https` | No |
+| `neo4j_uri` | `neo4j+s://<host>:7687` | No |
+| `neo4j_uri_https` | `https://<host>:7473/db/neo4j/query/v2` | No |
+| `neo4j_database` *(if required by your app)* | `neo4j` | No |
+| `neo4j_neo4j_username` | `neo4j` | No |
+| `neo4j_neo4j_password` | Neo4j password — from your credentials store | **Yes** |
+| `neo4j_neo4j_https` ⚠️ | **base64 of `username:password`** — see [section 3](#3-the-neo4j_neo4j_https-token) | **Yes** |
+| `mqtt_broker` | `<host>` | No |
+| `mqtt_port` ⚠️ | `9003` (**not** 1883 — App Designer uses the websocket port) | No |
+| `mqtt_protocol` | `wss://` | No |
+| `mqtt_xmpro_username` | `xmpro` | No |
+| `mqtt_xmpro_password` | MQTT `xmpro` user password — from your credentials store | **Yes** |
+| `ollama_host_url` | `https://<host>:11443` | No |
+| `ollama_embedding_model` | your embedding model name | No |
+| `ollama_inference_model` | your inference model name | No |
+| `timescaledb_host` | `<host>` | No |
+| `timescaledb_port` | `5432` | No |
+| `timescaledb_database` | `timescaledb` | No |
+| `timescaledb_postgres_username` | `postgres` | No |
+| `timescaledb_postgres_password` | Postgres/TimescaleDB password — from your credentials store | **Yes** |
+| `vector_db_type` | `milvus-https` | No |
+| `vector_url` | `https://<host>:19531` | No |
+| `vector_db_name` | `default` | No |
+| `vector_api_key` | vector DB API key — from your credentials store | **Yes** |
+
+---
+
+## 3. The `neo4j_neo4j_https` token
+
+App Designer talks to Neo4j over the **HTTPS Query API** (`neo4j_uri_https` → `https://<host>:7473/db/neo4j/query/v2`), which authenticates with an **HTTP Basic** header. The `neo4j_neo4j_https` variable holds that token: the base64 encoding of `username:password`.
+
+**Docker deployment — no manual encoding needed.** The installer pre-computes this and writes it into `CREDENTIALS.txt` under the Neo4j section:
+
+```
+App Designer variable 'neo4j_neo4j_https' (base64 of username:password):
+  bmVvNGo6eW91cnBhc3N3b3Jk
+```
+
+Copy that value straight into the `neo4j_neo4j_https` variable (mark it **Secure**).
+
+**Any other deployment — compute it yourself** from your Neo4j username and password:
+
+```bash
+# Linux / macOS
+printf '%s:%s' "neo4j" "YOUR_NEO4J_PASSWORD" | base64
+```
+
+```powershell
+# Windows PowerShell
+[Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes("neo4j:YOUR_NEO4J_PASSWORD"))
+```
+
+Re-run this whenever the Neo4j password changes.
+
+---
+
+## 4. Watch-outs
+
+- **`mqtt_port` is not the same in both apps** — Stream Designer uses `1883` (native MQTT), App Designer uses `9003` (MQTT over websockets, paired with `mqtt_protocol=wss://`). Copying 1883 into App Designer is the most common mistake.
+- **Secure variables** — always create the five password/key/token variables as Secure so they are masked and excluded from plain-text exports.
+- **Host and ports must match your deployment** — the URLs above assume the SSL-enabled stack (7473/7687 for Neo4j, 11443 for Ollama, 19531 for the vector DB). Adjust if you deployed on different ports or without SSL.
+- **Ollama model names** are environment-specific — set them to the exact models you pulled for embedding and inference.
+
+## 5. Verify
+
+- [ ] Every Secure variable resolves against the value in your credentials store.
+- [ ] `neo4j_neo4j_https` matches the token in `CREDENTIALS.txt` (Docker) or your recomputed value.
+- [ ] Stream Designer: the MAGS stream starts and connects to Neo4j, MQTT (1883), TimescaleDB, and the vector DB without connection errors.
+- [ ] App Designer: pages load MAGS data over the HTTPS Query API and MQTT over websockets (9003).


### PR DESCRIPTION
## What

Adds the missing post-installation step: a run sheet for creating the **Stream Designer** and **App Designer** Variables that connect a deployed MAGS stream and app to the infrastructure stack (Neo4j, MQTT, TimescaleDB, vector DB, Ollama).

The installation guide previously stopped after infra + cypher + agent profiles and never told installers to create these variables, so freshly deployed stacks had no connection details wired up.

## Changes

- **New** `docs/installation/post-install-configuration.md` — deployment-agnostic run sheet:
  - Separate **Stream Designer** and **App Designer** variable tables. The apps share the same variables, but each encrypts values with its **own key**, so every variable must be entered separately in each app.
  - Dedicated section for `neo4j_neo4j_https` (the base64 Basic-auth token for the Neo4j HTTPS Query API), with copy-from-CREDENTIALS.txt for Docker and encode-it-yourself snippets otherwise.
  - Watch-outs (notably `mqtt_port` = 1883 in Stream Designer vs 9003 in App Designer) and a verify checklist.
- **Installer** `docker-stack-installer.ps1` / `.sh` — pre-compute the `neo4j_neo4j_https` token (base64 of `username:password`) and write it into the Neo4j section of `CREDENTIALS.txt`, labelled for App Designer, so the trickiest value is copy-paste.
- **Links** from `installation.md` Next Steps and the docker `README.md` After Installation section.

Docs + installer-output only; no runtime code paths touched.

## Test plan

- [ ] Run `docker-stack-installer.ps1` (Windows) and `.sh` (Linux); confirm `CREDENTIALS.txt` Neo4j section now includes the `neo4j_neo4j_https` base64 token, and that it decodes to `username:password`.
- [ ] Confirm the run sheet renders on GitHub and both cross-links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)