### PR TITLE
docs: update for three-database hybrid (TimeSeries) architecture

### DIFF
--- a/docs/Glossary.md
+++ b/docs/Glossary.md
@@ -185,7 +185,9 @@ Remember, this glossary is a living document. Your input and expertise help make
 
 ### D
 
-**Database Manager**: A component that handles all database operations including memory storage, retrieval, and management across different database types.
+**Database Manager**: A component that handles all database operations including memory storage, retrieval, and management across the hybrid architecture's TimeSeries, Graph, and Vector databases.
+
+**DatabaseWriteSaga**: The Saga-pattern component that coordinates writes across the hybrid databases — writing the TimeSeries source of truth first, then the Vector and Graph references, then verifying checksums across stores and queueing any mismatches for repair. See [TimeSeries Storage & Hybrid Database Architecture](technical-details/timeseries-storage.md).
 
 **DataStreams**: XMPro's visual, no-code platform for creating real-time data processing pipelines that serve as the foundation for MAGS agent deployment, providing the separation of control between agent reasoning and execution.
 
@@ -519,6 +521,10 @@ Remember, this glossary is a living document. Your input and expertise help make
 **Telemetry Flusher**: A component responsible for ensuring telemetry data is properly sent to monitoring systems.
 
 **Telemetry Setup**: Configuration and initialization of telemetry collection across the system.
+
+**TimeSeries Database**: The source-of-truth store in the hybrid architecture, holding the full content, scores, metrics, and audit history of memories, conversations, decisions, and plans. Optimized for high-volume, time-ordered writes and time-based analytics; implemented on TimescaleDB (PostgreSQL) or InfluxDB 3. See [TimeSeries Storage & Hybrid Database Architecture](technical-details/timeseries-storage.md).
+
+**TimeSeries Database Type**: Enumeration of supported time-series databases (TimescaleDB, InfluxDB 3).
 
 **Token Probability**: Statistical information about token likelihood in language model responses.
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -49,7 +49,7 @@ graph TD
 - Agent Instances
 - Memory Cycle
 - MQTT Manager
-- Database Manager (Neo4j and Vector Database)
+- Database Manager (TimeSeries, Graph, and Vector databases — see [TimeSeries Storage](../technical-details/timeseries-storage.md))
 - Language Model
 - Prompt Manager
 - Planning Strategies
@@ -86,8 +86,9 @@ graph TD
     MC[MemoryCycle] --> |Uses| LM[Language Model]
     MC --> |Uses| DBM[Database Manager]
     MC --> |Communicates via| MQTT[MQTT Manager]
-    DBM --> |Interfaces with| Neo4j[Neo4j Database]
-    DBM --> |Interfaces with| VDB[Vector Database]
+    DBM --> |Source of truth| TS[TimeSeries Database]
+    DBM --> |References + relationships| Neo4j[Graph Database]
+    DBM --> |Embeddings| VDB[Vector Database]
     MC --> |Uses| EM[Embedding Model]
     MC --> |Guided by| PM[Prompt Manager]
     MC --> |Plans with| PS[Planning Strategies]

--- a/docs/concepts/agent-messaging.md
+++ b/docs/concepts/agent-messaging.md
@@ -130,17 +130,20 @@ The agent sends two types of responses:
    }
    ```
 
-   > **Important**: The final response contains only metadata. To retrieve the actual conversation content, you must query the graph database using the conversation_id. See [Graph Database Queries](#graph-database-queries) below.
+   > **Important**: The final response contains only metadata. To retrieve the actual conversation content, query the **TimeSeries database** using the conversation_id. See [Retrieving Content](#retrieving-content) below.
 
-### Graph Database Queries
+### Retrieving Content
 
-To get the conversation details after receiving the final response:
+> **Architecture note (breaking change):** MAGS uses a [three-database hybrid architecture](../technical-details/timeseries-storage.md). The **TimeSeries DB is the source of truth** for all content — prompts, responses, summaries, key points, PDDL, metrics. The Graph DB now holds only **lightweight reference nodes** (id, type, `timeseries_id`, `checksum`) and the relationships between them. Older documentation and clients that read `prompt` / `response` / `reply` fields directly off Graph nodes will get `NULL` — those fields moved to the TimeSeries DB.
 
-```cypher
-MATCH (c:Artifact {type: 'Conversation', id: $conversationId})-[:HAS_ENTRY]->(start:Entry)
-MATCH path = (start)-[:NEXT*0..]->(e:Entry)
-RETURN e.reply as reply, e.prompt as prompt, e.response as response, e.summary as summary, e.user_query as user_query, e.timestamp as timestamp
-ORDER BY e.timestamp ASC
+To get the conversation details after receiving the final response, query the TimeSeries DB by `conversation_id`:
+
+```sql
+SELECT entry_id, prompt, reply, response, summary, user_query, time,
+       total_token_usage, response_time
+FROM mags_conversation_entries
+WHERE conversation_id = :conversation_id
+ORDER BY time ASC;
 ```
 
 This returns the complete conversation history including:
@@ -149,8 +152,17 @@ This returns the complete conversation history including:
 - Original user queries
 - Timestamps
 - Performance metrics (token usage, response times)
-- Tool usage information
-- Any observations triggered by the conversation
+
+If you need the exact threaded order or want to pull related artifacts, first get the ordered entry references from the Graph DB, then fetch content from the TimeSeries DB by `entry_id`:
+
+```cypher
+MATCH (c:Artifact {type: 'Conversation', id: $conversationId})-[:HAS_ENTRY]->(start:Entry)
+MATCH path = (start)-[:NEXT*0..]->(e:Entry)
+RETURN e.entry_id AS entry_id, e.summary AS summary, e.timestamp AS timestamp
+ORDER BY e.timestamp ASC
+```
+
+> A read-only REST API over the TimeSeries DB is also available via PostgREST when you expose the relevant tables through an `api` view. See [TimeSeries Storage](../technical-details/timeseries-storage.md#optional-rest-access-via-postgrest).
 
 ### Example Conversation Flow
 
@@ -167,7 +179,7 @@ Here's a typical chat interaction sequence:
 sequenceDiagram
     participant C as Client
     participant A as Agent
-    participant DB as Graph Database
+    participant TS as TimeSeries DB
     
     Note over C,A: Step 1: Initialize Conversation
     C->>A: chat/new (with new conversation_id)
@@ -179,16 +191,16 @@ sequenceDiagram
     A->>C: progress update (75%)
     A->>C: chat response (metadata only)
     
-    Note over C,DB: Step 3: Retrieve Response
-    C->>DB: Query conversation details
-    DB->>C: Complete conversation history
+    Note over C,TS: Step 3: Retrieve Response
+    C->>TS: Query conversation content by conversation_id
+    TS->>C: Complete conversation history
     
     Note over C,A: Step 4: Continue Conversation
     C->>A: next message (same conversation_id)
     A->>C: progress update
     A->>C: chat response (metadata only)
-    C->>DB: Query updated conversation
-    DB->>C: Updated conversation history
+    C->>TS: Query updated conversation
+    TS->>C: Updated conversation history
 ```
 
 ### Important Notes
@@ -233,12 +245,16 @@ When an observation is triggered, you'll receive a metadata message:
 }
 ```
 
-To retrieve the actual reflection content, query the graph database:
+To retrieve the actual observation content, query the TimeSeries DB by `memory_id` (the `observation_id` from the message):
 
-```cypher
-MATCH (m:Memory {id: $observationId})
-RETURN m
+```sql
+SELECT memory_id, memory_type, summary, key_points, actionable_insights,
+       importance, surprise, confidence_score, total_token_usage, time
+FROM mags_memory_records
+WHERE memory_id = :observation_id;
 ```
+
+> The Graph DB `Memory` node for this id holds only `id`, `type`, `timeseries_id`, and `checksum` — use it for relationship traversal, not content.
 
 ### 2. Receiving Reflection Results
 
@@ -256,11 +272,13 @@ When a reflection is triggered, you'll receive a metadata message:
 }
 ```
 
-To retrieve the actual reflection content, query the graph database:
+To retrieve the actual reflection content, query the TimeSeries DB by `memory_id` (the `reflection_id` from the message):
 
-```cypher
-MATCH (m:Memory {id: $reflectionId})
-RETURN m
+```sql
+SELECT memory_id, memory_type, summary, key_points, actionable_insights,
+       importance, surprise, confidence_score, total_token_usage, time
+FROM mags_memory_records
+WHERE memory_id = :reflection_id;
 ```
 
 ## Planning
@@ -335,17 +353,30 @@ The agent sends several types of plan-related messages:
 }
 ```
 
-As with conversations, observations and reflections, to get the complete plan details, query the graph database:
+Plans are stored across both stores: the Graph DB holds the plan → task → action **hierarchy** with a `timeseries_id` on each node, and the TimeSeries DB holds the **content** (PDDL, full task and action detail, metrics).
+
+First get the structure and the `timeseries_id`s from the Graph DB:
 
 ```cypher
 MATCH (p:Artifact {type: 'Plan', active: true, agent_id: $agentId})
 OPTIONAL MATCH (p)-[:HAS_TASK]->(t:Entry {type: 'Task'})
 WHERE t.status <> 'Cancelled' OR t.status IS NULL
 OPTIONAL MATCH (t)-[:HAS_ACTION]->(a:Entry {type: 'Action'})
-RETURN p, 
- t,
- collect(a) as actions
- ```
+RETURN p.timeseries_id AS plan_id,
+       t.timeseries_id AS task_id, t.status AS task_status,
+       collect(a.timeseries_id) AS action_ids
+```
+
+Then fetch the heavy content from the TimeSeries DB by those ids — the PDDL document from `mags_plan_artifacts`, and task/action detail from `mags_plan_tasks` and `mags_plan_actions`:
+
+```sql
+SELECT plan_id, pddl_domain, pddl_problem, pddl_plan,
+       objective_function_score, confidence_score, total_token_usage, time
+FROM mags_plan_artifacts
+WHERE plan_id = :plan_id
+ORDER BY time DESC
+LIMIT 1;
+```
 
 ## Error Responses
 
@@ -366,10 +397,10 @@ If something goes wrong, you'll receive an error message:
 
 ## Important Notes
 
-1. Both chat responses, observation and reflection results return only metadata through the message broker
-2. The actual content must be retrieved from the graph database using the provided Ids
+1. Chat responses, observation and reflection results return only metadata through the message broker
+2. The actual content is retrieved from the **TimeSeries database** using the provided Ids (the Graph DB holds only lightweight references and relationships — see [TimeSeries Storage & Hybrid Database Architecture](../technical-details/timeseries-storage.md))
 3. This pattern allows for:
    - Efficient real-time messaging
-   - Complete content storage and retrieval
-   - Historical querying and analysis
-   - Complex relationship tracking between conversations, observation and reflections
+   - Complete content storage and retrieval (source of truth in TimeSeries)
+   - Historical querying and time-based analytics
+   - Complex relationship tracking (in the Graph DB) between conversations, observations and reflections

--- a/docs/concepts/howmagsusememory.md
+++ b/docs/concepts/howmagsusememory.md
@@ -18,7 +18,7 @@ The long-term memory system in MAGS stores five main types of information:
 4. Decisions: Documentation of past decision-making processes
 5. Actions: History of completed operations
 
-This structured approach helps agents learn from past experiences and apply that knowledge to new situations. We use a combination of graph and vector databases to store this information, which allows agents to find relevant memories quickly and understand the relationships between different pieces of information.
+This structured approach helps agents learn from past experiences and apply that knowledge to new situations. We use a combination of time-series, graph, and vector databases to store this information: the time-series database holds the full content and history, the vector database lets agents find relevant memories quickly, and the graph database captures the relationships between different pieces of information.
 
 ## How MAGS Processes and Uses Memories
 

--- a/docs/concepts/whymags.md
+++ b/docs/concepts/whymags.md
@@ -22,19 +22,23 @@ XMPro MAGS is built on robust messaging protocols, making it suitable for indust
 
 The use of these protocols ensures that MAGS can operate effectively in large-scale industrial deployments. It can handle high-volume data streams and maintain communication integrity even in unstable network conditions. This infrastructure is particularly valuable in environments where real-time data processing and agent communication are critical for operations.
 
-### Dual-Database Approach for Enhanced Cognition
+### Hybrid Database Approach for Enhanced Cognition
 
-MAGS employs two specialized databases to improve its cognitive capabilities:
+MAGS employs a [three-database hybrid architecture](../technical-details/timeseries-storage.md), with each store optimized for what it does best:
 
-1. **Vector Database**:
+1. **TimeSeries Database (TimescaleDB / InfluxDB 3)**:
+   - The source of truth for all content, scores, metrics, and audit history
+   - Purpose-built for high-volume, time-ordered writes and time-based analytics
+
+2. **Vector Database**:
    - Enables efficient semantic similarity searches
    - Supports advanced AI operations and retrieval-augmented generation (RAG)
 
-2. **Graph Database (Neo4j)**:
-   - Represents complex relationships between entities
+3. **Graph Database (Neo4j)**:
+   - Holds lightweight reference nodes and the relationships between entities
    - Facilitates nuanced reasoning about interconnected data
 
-This dual-database system allows MAGS to process and understand complex data relationships more effectively than systems using simpler database structures. The Vector Database enables quick retrieval of semantically similar information, while the Graph Database provides context and relational understanding. Together, they enable MAGS to make more informed decisions based on a comprehensive understanding of the data landscape.
+This hybrid system allows MAGS to process and understand complex data relationships more effectively than systems using simpler database structures. The TimeSeries Database is the durable record of what happened, the Vector Database enables quick retrieval of semantically similar information, and the Graph Database provides context and relational understanding. Together, they enable MAGS to make more informed decisions based on a comprehensive understanding of the data landscape.
 
 ### Integrated Memory Cycle
 

--- a/docs/concepts/whymagspt2.md
+++ b/docs/concepts/whymagspt2.md
@@ -26,7 +26,13 @@ XMPro MAGS is built on a robust, industrial-grade architecture that sets it apar
 
 ### 2. Advanced Data Management
 
-XMPro MAGS employs a sophisticated dual-database approach, combining the strengths of vector and graph databases to offer unparalleled data management capabilities.
+XMPro MAGS employs a sophisticated [three-database hybrid approach](../technical-details/timeseries-storage.md), combining the strengths of time-series, vector, and graph databases to offer unparalleled data management capabilities.
+
+#### TimeSeries Database
+
+- The source of truth for all agent content, scores, metrics, and audit history
+- Purpose-built for high-volume, time-ordered writes and time-based analytics
+- Ideal for durable audit trails, decision provenance, and long-term trend analysis in industrial workflows
 
 #### Vector Database
 
@@ -36,11 +42,11 @@ XMPro MAGS employs a sophisticated dual-database approach, combining the strengt
 
 #### Graph Database
 
-- Manages structured relationships between entities
+- Manages structured relationships between entities (lightweight references, not bulk content)
 - Represents complex interdependencies between agents, tasks, and decisions
 - Facilitates relational and temporal context mapping for informed decision-making
 
-> This dual-database architecture allows XMPro MAGS to efficiently handle both unstructured and structured data, enabling deep relational analysis and nuanced context-aware decision-making that traditional frameworks struggle to achieve.
+> This hybrid architecture allows XMPro MAGS to efficiently handle temporal, unstructured, and structured data together, enabling deep relational analysis and nuanced context-aware decision-making that traditional frameworks struggle to achieve.
 
 ### 3. Cognitive Decision-Making Capabilities
 
@@ -91,7 +97,7 @@ XMPro MAGS incorporates advanced machine learning techniques to ensure continuou
 
 #### Adaptive Knowledge Representation
 
-- Dynamically updates vector and graph databases with new information
+- Dynamically updates the time-series, vector, and graph databases with new information
 - Allows for evolving understanding of industrial processes and relationships
 - Supports transfer learning across different domains and applications
 

--- a/docs/faq/technical.md
+++ b/docs/faq/technical.md
@@ -101,7 +101,7 @@ MAGS includes two main [types of agents](../concepts/agent_types.md) (with a hyb
 
 Agents learn through:
 - [Continuous memory cycles](../technical-details/memory_cycle_instantiation.md) (Observation, Reflection, Planning, Action)
-- Experience accumulation in vector and graph databases
+- Experience accumulation in the time-series, vector, and graph databases
 - Feedback loops from outcomes and interactions
 - Integration of new information into their knowledge base
 
@@ -111,9 +111,10 @@ Agents learn through:
 
 ### What databases does MAGS use?
 
-MAGS employs a dual-database approach:
+MAGS employs a [three-database hybrid architecture](../technical-details/timeseries-storage.md):
+- [TimeSeries Database](../technical-details/timeseries-storage.md) (TimescaleDB or InfluxDB 3) — the source of truth for all content, metrics, and audit history
 - [Vector Database](../technical-details/vector_database.md) for semantic similarity searches
-- Graph Database (Neo4j) for complex relationship mapping
+- Graph Database (Neo4j, Memgraph, and others) for lightweight references and complex relationship mapping
 - Combined approach for enhanced cognitive capabilities
 
 ### What monitoring capabilities are available?
@@ -133,6 +134,7 @@ Monitoring is implemented through:
 
 Key prerequisites include:
 - Licensed XMPro installation
+- TimeSeries Database (TimescaleDB or InfluxDB 3)
 - Neo4j Graph Database
 - Milvus or Qdrant Vector Database
 - MQTT Broker

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -29,11 +29,15 @@ This guide provides detailed instructions for setting up the XMPro AI Agents sys
 
 ## Setup Steps
 
-### 1. Neo4j Configuration
+### 1. TimeSeries Database Configuration
+
+Provision a TimescaleDB (or InfluxDB 3) instance and supply its connection details in the agent's `timeseries` configuration. The MAGS schema (tables, hypertables, indexes, and the Saga repair queue) is created automatically on first startup via `InitializeSchemaAsync()` — no manual DDL is required. For a container-based deployment (including the optional PostgREST REST layer), see the [TimescaleDB deployment guide](installation/docker/src/timescaledb/timescaledb_readme.md). Background on what is stored and why is in [TimeSeries Storage & Hybrid Database Architecture](technical-details/timeseries-storage.md).
+
+### 2. Neo4j Configuration
 
 Run the Cypher commands found in `installation/constraints.cypher` to create the necessary constraints and indexes for the database.
 
-### 2. System Options Installation
+### 3. System Options Installation
 
 Execute the Cypher commands found in `installation/system_options.cypher` to set up system options. Before running:
 
@@ -42,15 +46,15 @@ Execute the Cypher commands found in `installation/system_options.cypher` to set
     - All available options are: `Anthropic`, `AWSBedrock`, `AzureOpenAI`, `Google`, `Ollama`, `OpenAI`
 - Edit the `rag_schema` to match your RAG collection schemas. Each collection can have a different schema.
 
-### 3. Prompt Library Installation
+### 4. Prompt Library Installation
 
 Execute the Cypher commands found in `installation/library_prompts.cypher` to set up the system prompts.
 
-### 4. Tools Library Installation
+### 5. Tools Library Installation
 
 Execute the Cypher commands found in `installation/library_tools.cypher` to set up the tool options. 
 
-### 5. Agent Profiles
+### 6. Agent Profiles
 
 Agent profiles are essential components of the XMPro AI Agents system, defining the characteristics, capabilities, and behavior of each agent. They serve as templates for creating agent instances.
 

--- a/docs/technical-details/README.md
+++ b/docs/technical-details/README.md
@@ -10,7 +10,8 @@ This folder contains in-depth technical explanations and specifications for vari
 5. [Open Telemetry Tracing Guide](open_telemetry_tracing_guide.md)
 6. [Prompt Injection Protection](prompt-injection-protection.md)
 7. [Prompt Manager and Library](https://xmpro.github.io/Blueprints-Accelerators-Patterns/metablocks/admin-prompt/)
-8. [Vector Database](vector_database.md)
+8. [TimeSeries Storage & Hybrid Database Architecture](timeseries-storage.md)
+9. [Vector Database](vector_database.md)
 
 ### Agent Status Monitoring and Error Handling
 
@@ -31,7 +32,7 @@ This information is crucial for understanding how agent health and performance a
 - The complete memory creation process for both observations and reflections
 - Implementation details of Retrieval-Augmented Generation (RAG)
 - Integration with the planning system
-- Dual storage strategy using Neo4j and vector databases
+- Three-database hybrid storage strategy (TimeSeries source of truth, Graph references, Vector embeddings)
 - Comprehensive metrics and monitoring approach
 
 This document is essential for understanding how agents process information, make decisions, and maintain their knowledge base. It includes detailed diagrams and explanations of the data flow between components.
@@ -89,6 +90,18 @@ This document provides a comprehensive overview of our Prompt Management System.
 - User interface components
 
 This information is crucial for understanding how prompts are created, stored, managed, and accessed within our system.
+
+### TimeSeries Storage & Hybrid Database Architecture
+
+[timeseries-storage.md](timeseries-storage.md) explains the three-database hybrid architecture that underpins MAGS storage. It covers:
+
+- Why content is split across TimeSeries, Graph, and Vector databases
+- What is stored where, including the full list of `mags_*` TimeSeries tables
+- The Saga write path (TimeSeries first, then references, then checksum verification)
+- How to retrieve content — the two-step hybrid read pattern, with SQL and optional PostgREST examples
+- Configuration and storage management (compression, continuous aggregates, retention)
+
+This document is essential reading if you consume agent content directly (the source of truth moved from the Graph DB to the TimeSeries DB).
 
 ### Vector Database
 

--- a/docs/technical-details/memory_cycle.md
+++ b/docs/technical-details/memory_cycle.md
@@ -20,7 +20,9 @@ graph TB
     VectorDBAbstract[AbstractVector Base Class]
     
     MQTT[Message Broker/MQTT]
-    Neo4j[(Neo4j Graph Database)]
+    Saga[DatabaseWriteSaga]
+    TS[(TimeSeries DB<br/>Source of Truth)]
+    Neo4j[(Graph DB<br/>References + Relationships)]
     LLM[Language Model]
     
     MQTT -->|Receives Input| Agent
@@ -35,11 +37,12 @@ graph TB
     RAGProcessor -->|3 Queries Vector DB| VectorDBAbstract
     RAGProcessor -->|4 Returns Context| MC
     
-    ObsM -->|Stores| Neo4j
-    ObsM -->|Vectorizes & Stores| VectorDBAbstract
-    RefM -->|Stores| Neo4j
-    RefM -->|Vectorizes & Stores| VectorDBAbstract
-    Plan -->|Stores| Neo4j
+    ObsM -->|Writes via| Saga
+    RefM -->|Writes via| Saga
+    Plan -->|Writes via| Saga
+    Saga -->|1 Full content| TS
+    Saga -->|2 Embedding| VectorDBAbstract
+    Saga -->|3 Lightweight reference + checksum| Neo4j
     
     MC -->|Generates Responses| LLM
     LLM -->|Enhanced with RAG Context| MC
@@ -70,8 +73,8 @@ graph TB
     classDef vectorDB fill:#ff9,stroke:#333,stroke-width:2px
     classDef collection fill:#9cf,stroke:#333,stroke-width:2px
     
-    class Agent,MC,ObsM,RefM,Plan mainComponent
-    class Neo4j database
+    class Agent,MC,ObsM,RefM,Plan,Saga mainComponent
+    class Neo4j,TS database
     class EmbeddingModel,RAGProcessor ragComponent
     class MQTT,LLM external
     class VectorDBAbstract,Milvus,Qdrant,MongoDB vectorDB
@@ -83,7 +86,7 @@ graph TB
 ### 1. Initialization & Setup
 
 The Memory Cycle initializes with several key components:
-- Database Manager (Neo4j and Vector DBs)
+- Database Manager (TimeSeries, Graph, and Vector DBs — see [TimeSeries Storage & Hybrid Database Architecture](timeseries-storage.md))
 - Language Model integration
 - Message Broker (MQTT/DDS)
 - OpenTelemetry for tracing/metrics
@@ -115,10 +118,10 @@ When a new observation is triggered:
 3. Importance score is calculated:
    - Uses LLM to evaluate importance (0-1 scale)
    - Considers agent goals and current context
-4. Memory is stored:
-   - Vector representation in chosen Vector DB
-   - Relationship data in Neo4j
-   - Additional metadata and metrics
+4. Memory is stored via the DatabaseWriteSaga:
+   - Full content, scores, and metrics in the TimeSeries DB (source of truth)
+   - Vector representation in the chosen Vector DB
+   - Lightweight reference node (id, timeseries_id, checksum) and relationships in the Graph DB
 ```
 
 ```mermaid
@@ -128,6 +131,7 @@ sequenceDiagram
     participant EM as Embedding Model
     participant VDB as Vector DB
     participant LLM
+    participant TS as TimeSeries
     participant Neo4j
     
     Input->>MC: New Observation
@@ -149,13 +153,14 @@ sequenceDiagram
     end
     
     rect rgb(200, 230, 255)
-        Note over MC,Neo4j: Importance & Storage
+        Note over MC,Neo4j: Importance & Storage (Saga)
         MC->>LLM: Calculate Importance
         LLM-->>MC: Return Score (0-1)
+        MC->>TS: 1. Store full content + scores + metrics
         par Store in Vector DB
-            MC->>VDB: Store Vector Representation
-        and Store in Graph DB
-            MC->>Neo4j: Store Relationships & Metadata
+            MC->>VDB: 2. Store Vector Representation
+        and Store reference in Graph DB
+            MC->>Neo4j: 3. Store lightweight reference + relationships + checksum
         end
     end
 ```
@@ -188,6 +193,7 @@ sequenceDiagram
     participant T as Trigger System
     participant MC as Memory Cycle
     participant VDB as Vector Database
+    participant TS as TimeSeries
     participant Neo4j
     participant EM as Embedding Model
     participant LLM
@@ -198,8 +204,10 @@ sequenceDiagram
     
     rect rgb(200, 230, 255)
         Note over MC,Neo4j: Memory Collection Phase
-        MC->>Neo4j: Fetch Recent Memories
-        Neo4j-->>MC: Return Memory Records
+        MC->>Neo4j: Fetch recent memory references (ids + relationships)
+        Neo4j-->>MC: Return references
+        MC->>TS: Fetch full memory content by id
+        TS-->>MC: Return Memory Records
         MC->>MC: Apply Time Decay
         MC->>EM: Generate Memory Embeddings
         EM->>VDB: Query Similar Memories
@@ -223,12 +231,13 @@ sequenceDiagram
     end
     
     rect rgb(230, 200, 255)
-        Note over MC,Neo4j: Storage
+        Note over MC,Neo4j: Storage (Saga)
+        MC->>TS: Store full reflection content + metrics
         par Store in Vector DB
             MC->>EM: Generate Embedding
             EM->>VDB: Store Vector
-        and Store in Graph DB
-            MC->>Neo4j: Store Reflection
+        and Store reference in Graph DB
+            MC->>Neo4j: Store lightweight reference + checksum
             MC->>Neo4j: Create Memory Links
         end
     end
@@ -266,6 +275,7 @@ sequenceDiagram
     participant Plan as PlanningSystem
     participant LLM
     participant Neo4j
+    participant TS as TimeSeries
     participant VDB as Vector DB
     participant Agent as Other Agents
     participant MB as Message Broker
@@ -298,8 +308,10 @@ sequenceDiagram
             MC->>PlanA: ShouldTriggerPlanningAsync
         end
 
-        PlanA->>Neo4j: Get Current Plan
-        Neo4j-->>PlanA: Return Plan Details
+        PlanA->>Neo4j: Get current plan reference (timeseries_id)
+        Neo4j-->>PlanA: Return reference
+        PlanA->>TS: Fetch full plan (PDDL, tasks) by id
+        TS-->>PlanA: Return Plan Details
         PlanA->>VDB: Query Similar Memories
         VDB-->>PlanA: Return Relevant Context
         PlanA->>LLM: Evaluate Planning Need
@@ -314,7 +326,8 @@ sequenceDiagram
             Plan->>Plan: SelectPlanningMethod
             Plan->>LLM: Generate/Adjust Plan
             LLM-->>Plan: Return PDDL Plan
-            Plan->>Neo4j: Store Plan & Tasks
+            Plan->>TS: Store plan artifact, tasks & actions (content)
+            Plan->>Neo4j: Store lightweight plan/task/action references
             Plan->>MB: PublishNewPlan or PublishUpdatedPlan
             MB-->>Agent: Notify Plan Changes
         end
@@ -358,15 +371,30 @@ For each memory operation:
 
 ### 6. Storage & Persistence
 
-```plaintext
-Dual Storage Strategy:
-1. Neo4j Graph Database:
-   - Relationship data
-   - Temporal connections
-   - Metadata and metrics
-   - Planning linkages
+MAGS uses a **three-database hybrid architecture**. Every write spanning more than one
+store goes through the `DatabaseWriteSaga`, which writes the TimeSeries source of truth
+first, then the Vector embedding and the lightweight Graph reference, and finally verifies
+checksums across all three. See [TimeSeries Storage & Hybrid Database Architecture](timeseries-storage.md)
+for the full detail.
 
-2. Vector Database:
+```plaintext
+Three-Database Hybrid Strategy:
+1. TimeSeries Database (Source of Truth):
+   - Full content (prompts, responses, summaries, key points, PDDL)
+   - Significance and confidence scores
+   - Performance metrics and token usage
+   - Complete audit history
+   - Tables: mags_memory_records, mags_conversation_entries,
+     mags_decision_records, mags_plan_artifacts, ...
+
+2. Graph Database (References + Relationships):
+   - Lightweight reference nodes (id, type, timeseries_id, checksum)
+   - Relationships and traversal (conversation threading, plan hierarchies,
+     RELATED_TO / HAS_ENTRY / NEXT links)
+   - Agent / team / profile configuration
+   - NOT full content — that lives in the TimeSeries DB
+
+3. Vector Database:
    - Semantic embeddings
    - Fast similarity search
    - Collections separated by:
@@ -374,6 +402,11 @@ Dual Storage Strategy:
      * General knowledge
      * Different memory types
 ```
+
+> **Retrieving content:** the Graph and Vector stores return record **ids**; the full
+> content is then fetched from the TimeSeries DB by id. See
+> [Agent Messaging Protocol](../concepts/agent-messaging.md#retrieving-content) for
+> concrete retrieval queries.
 
 ### 7. Metrics & Monitoring
 

--- a/docs/technical-details/memory_cycle_instantiation.md
+++ b/docs/technical-details/memory_cycle_instantiation.md
@@ -7,7 +7,7 @@ The agent instantiation process in XMPro MAGS (Multi-Agent System) involves seve
 1. **Memory Cycle Factory**: Responsible for creating and configuring the MemoryCycle instance.
 2. **Memory Cycle**: The core component managing an agent's cognitive processes.
 3. **Message Broker**: Handles message based communication for the agent.
-4. **Database Manager**: Manages interactions with Neo4j and vector databases.
+4. **Database Manager**: Manages interactions with the TimeSeries (source of truth), Graph, and Vector databases. See [TimeSeries Storage & Hybrid Database Architecture](timeseries-storage.md).
 5. **Language Model**: Provides natural language processing capabilities.
 6. **Open Telemetry**: Configures telemetry for monitoring and logging.
 
@@ -70,8 +70,9 @@ graph TD
     MC --> |Plans with| PSF[Planning Strategy Factory]
     MC --> |Guided by| PM[Prompt Manager]
     MC --> |Uses| TL[Tool Library]
-    DBM --> |Interfaces with| Neo4j[Neo4j Database]
-    DBM --> |Interfaces with| VDB[Vector Database]
+    DBM --> |Source of truth| TS[TimeSeries Database]
+    DBM --> |References + relationships| Neo4j[Graph Database]
+    DBM --> |Embeddings| VDB[Vector Database]
     PSF --> |Creates| PS[Planning Strategies]
 ```
 
@@ -81,8 +82,10 @@ The process begins by setting up various configuration dictionaries with the set
 
 | Config                | For                                  |
 |-----------------------|--------------------------------------|
-| `neo4jConfig`         | For Neo4j database connection        |
+| `graphDbConfig`       | For the graph database connection (Neo4j, Memgraph, etc.) |
 | `vectorDbConfig`      | For vector database configuration    |
+| `timeSeriesDbConfig`  | For the TimeSeries database (source of truth) connection |
+| `tripleStoreConfig`   | For the optional TripleStore (semantic features); may be null |
 | `embeddingConfig`     | For embedding model configuration    |
 | `languagemodelConfig` | For language model configuration     |
 | `messageBrokerConfig` | For message broker communication configuration |
@@ -97,8 +100,10 @@ The `MemoryCycleFactory.CreateMemoryCycle()` method is called with these configu
 var config = SetupConfiguration();
 
 memoryCycle = MemoryCycleFactory.CreateMemoryCycle(
-    (Dictionary<string, object>)config["neo4jConfig"],
+    (Dictionary<string, object>)config["graphDbConfig"],
     (Dictionary<string, object>)config["vectorDbConfig"],
+    (Dictionary<string, object>)config["timeSeriesDbConfig"],
+    (Dictionary<string, object>)config["tripleStoreConfig"], // optional; may be null
     (Dictionary<string, object>)config["embeddingConfig"],
     (Dictionary<string, object>)config["languagemodelConfig"],
     (Dictionary<string, object>)config["messageBrokerConfig"],
@@ -113,15 +118,16 @@ The `CreateMemoryCycle` method performs the following steps:
 |---------------------------------|-------------------------------|---------------------------------------------------------------------------------------------------------------------------|
 | 1. Initialize ServiceCollection | a. Configure telemetry        | - Set up telemetry and adds default logging |
 |                                 | b. Build ServiceProvider      | - Create the ServiceProvider |
-| 2. Initialize Components        | a. Create Neo4jConnectionPool | - Set up connection pool for Neo4j graph database |
-|                                 | b. Initialize vector database | - Set up the required vector database |
-|                                 | c. Initialize embedding model | - Set up the required embedding |
-|                                 | d. Initialize LanguageModel   | - Set up all language models (These are created on demand within the code when needed) |
-|                                 | e. Create DatabaseManager     | - Set up manager for database operations |
-|                                 | f. Load SystemOptions         | - Load system-wide options |
-|                                 | g. Initialize Message Broker     | - Set up manager for message broker communications |
-|                                 | h. Initialize GlobalExceptionHandler | - Set up global exception handling |
-|                                 | i. Initialize ToolLibrary     | - Set up library for agent tools |
+| 2. Initialize Components        | a. Create graph connection pool | - Set up connection pool for the graph database |
+|                                 | b. Initialize TimeSeries database | - Connect and create the schema via `InitializeSchemaAsync()` (idempotent) |
+|                                 | c. Initialize vector database | - Set up the required vector database |
+|                                 | d. Initialize embedding model | - Set up the required embedding |
+|                                 | e. Initialize LanguageModel   | - Set up all language models (These are created on demand within the code when needed) |
+|                                 | f. Create DatabaseManager     | - Set up manager for database operations |
+|                                 | g. Load SystemOptions         | - Load system-wide options |
+|                                 | h. Initialize Message Broker     | - Set up manager for message broker communications |
+|                                 | i. Initialize GlobalExceptionHandler | - Set up global exception handling |
+|                                 | j. Initialize ToolLibrary     | - Set up library for agent tools |
 | 3. Register Services            | a. Add singletons             | - Register Database Manager, Language Model, Message Broker, Open Telemetry Setup, Prompt Manager, Planning Strategy Factory, Tool Library, Plan Adapter Detector as singletons |
 |                                 | b. Register strategies        | - Register planning strategies and optimization algorithms |
 | 4. Create MemoryCycle Instance  | Return new MemoryCycle        | - Create and return a new MemoryCycle instance with all initialized components |

--- a/docs/technical-details/timeseries-storage.md
+++ b/docs/technical-details/timeseries-storage.md
@@ -1,0 +1,246 @@
+# TimeSeries Storage & Hybrid Database Architecture
+
+## Overview
+
+XMPro MAGS uses a **three-database hybrid architecture**. Each store is optimized for the job it does best, and a single logical record (a memory, a conversation entry, a decision, a plan) is split across them:
+
+1. **TimeSeries DB** (TimescaleDB, or InfluxDB 3) — the **source of truth** for all temporal, content-bearing data.
+2. **Vector DB** (Milvus, Qdrant, MongoDB Atlas) — semantic embeddings for similarity search.
+3. **Graph DB** (Neo4j, Memgraph, Cosmos DB Gremlin, Neptune) — lightweight references and the relationships between records.
+
+This replaced the earlier dual-store model (Graph + Vector) in which the graph database held the full content of every memory, conversation, and plan. Under the hybrid model the graph holds only a **thin reference node** — an id, a type, a timestamp, a `timeseries_id`, and a `checksum` — while the heavy content (prompts, responses, summaries, PDDL, token metrics) lives in the TimeSeries database.
+
+> **If you have code or documentation that reads agent content directly out of the graph database, it needs updating.** Graph nodes no longer carry `prompt`, `response`, `reply`, `key_points`, PDDL, or metric fields. See [Retrieving Content](#retrieving-content) below.
+
+## Why This Split
+
+| Concern | Store | Reason |
+|---------|-------|--------|
+| Full content + metrics + audit history | TimeSeries | Purpose-built for high-volume, time-ordered writes; automatic partitioning by time; compression; time-bucketed analytics |
+| "Which memories are similar to this?" | Vector | Approximate nearest-neighbour search over embeddings |
+| "What is related to what?" / traversal | Graph | Relationship queries, conversation threading, plan → task → action hierarchies |
+
+Keeping the graph lightweight keeps traversals fast and the graph small, while the TimeSeries database absorbs the write volume and long-term retention.
+
+## Architecture
+
+```mermaid
+graph TB
+    MC[Memory Cycle]
+    Saga[DatabaseWriteSaga]
+
+    TS[(TimeSeries DB<br/>Source of Truth)]
+    VDB[(Vector DB<br/>Embeddings)]
+    Graph[(Graph DB<br/>References + Relationships)]
+
+    MC -->|Write| Saga
+    Saga -->|"1 Full content (must succeed)"| TS
+    Saga -->|"2 Embedding (eventual)"| VDB
+    Saga -->|"3 Lightweight reference + timeseries_id + checksum"| Graph
+    Saga -->|"4 Verify checksums"| TS
+
+    MC -->|"Read: find ids"| Graph
+    MC -->|"Read: find similar"| VDB
+    MC -->|"Read: fetch full content by id"| TS
+
+    classDef sot fill:#69b,stroke:#333,stroke-width:2px,color:#fff
+    classDef ref fill:#ff9,stroke:#333,stroke-width:2px
+    class TS sot
+    class VDB,Graph ref
+```
+
+## What Is Stored Where
+
+### TimeSeries DB (source of truth)
+
+All content-bearing, temporal records. Tables follow the `mags_<domain>_<type>` naming convention:
+
+| Table | Purpose |
+|-------|---------|
+| `mags_memory_records` | Observations and reflections (summary, key points, actionable insights, significance & confidence scores, token metrics) |
+| `mags_conversation_summaries` | Rolling conversation summaries (Tier 1 memory) |
+| `mags_conversation_entries` | Agent-to-agent and agent-to-user conversation turns (prompt, reply, response, summary, user query) |
+| `mags_decision_records` | All decision types (planning, communication, consensus) |
+| `mags_planning_entries` | Planning-step LLM interactions |
+| `mags_plan_artifacts` | Complete plan documents (PDDL) |
+| `mags_plan_tasks` | Individual plan tasks |
+| `mags_plan_actions` | Plan action definitions |
+| `mags_tool_artifacts` | Tool-usage summaries (input, result, metrics) |
+| `mags_tool_attempts` | Individual tool-execution attempts |
+| `mags_tool_llm_calls` | LLM calls made during tool execution |
+| `mags_plan_audit_log` | Audit trail for plan/task changes |
+| `mags_sbom_records` | Software Bill of Materials |
+| `mags_objective_function_switching_entries` | Objective-function switching events |
+| `mags_repair_queue` | Saga-pattern repair tracking |
+
+Every table has `time TIMESTAMPTZ NOT NULL` as its first column (the hypertable dimension), a composite `PRIMARY KEY (<id>, time)`, and a `checksum` column for cross-database integrity verification.
+
+### Vector DB
+
+Semantic embeddings only, split into agent-specific and general-knowledge collections. See [Vector Database](vector_database.md).
+
+### Graph DB
+
+Lightweight reference nodes and relationships. A typical node carries:
+
+```
+id / entry_id     — the record identifier (also the join key into TimeSeries)
+type              — Memory | Conversation | Decision | Plan | Task | Action | ...
+created_date
+timestamp
+timeseries_id     — join key into the TimeSeries table
+checksum          — for integrity verification against the TimeSeries copy
+```
+
+Relationships are preserved in the graph exactly as before — `PARTICIPATED_IN`, `HAS_ENTRY`, `NEXT` (conversation threading), `HAS_TASK`, `HAS_ACTION`, `RELATED_TO`, `MADE`, etc.
+
+### Not stored in TimeSeries
+
+- **Measure / objective / utility-function data** — read-only from external XMPro DataStreams, referenced in the Graph DB.
+- **Agent / team / profile configuration** — static configuration in the Graph DB.
+- **Relationships** — Graph DB.
+- **Embeddings** — Vector DB.
+
+## The Write Path — Saga Pattern
+
+Writes that span more than one store go through `DatabaseWriteSaga`, which enforces ordering and consistency:
+
+```mermaid
+sequenceDiagram
+    participant MC as Memory Cycle
+    participant Saga as DatabaseWriteSaga
+    participant TS as TimeSeries (SoT)
+    participant Ref as Vector / Graph
+
+    MC->>Saga: ExecuteAsync(entityId, type, checksum, operations)
+    Saga->>TS: 1. Write full content
+    Note right of TS: Must succeed or the saga aborts
+    Saga->>Ref: 2. Write embedding + lightweight reference
+    Note right of Ref: Eventual consistency
+    Saga->>TS: 3. Verify checksums across stores
+    Saga-->>MC: WriteResult
+```
+
+1. **TimeSeries first.** The source-of-truth write must succeed; if it fails the operation aborts.
+2. **References second.** The embedding (Vector) and the lightweight reference node (Graph) are written, carrying the same `checksum`.
+3. **Verify.** Checksums are compared across stores. Failures are queued in `mags_repair_queue` for the self-healing subsystem to reconcile.
+
+TimeSeries-only records (no graph relationship needed) are written directly rather than through the saga.
+
+## Retrieving Content
+
+Because content moved out of the graph, retrieval is a **two-step, hybrid** operation:
+
+1. Find the relevant **ids** — either by traversing relationships in the Graph DB, or by similarity search in the Vector DB.
+2. Fetch the **full content** from the TimeSeries DB using those ids.
+
+For many read patterns you can skip the graph entirely and query TimeSeries directly, because the TimeSeries tables carry the natural foreign keys (`conversation_id`, `agent_id`, `memory_id`).
+
+### Example — a full conversation
+
+Direct from TimeSeries (simplest):
+
+```sql
+SELECT entry_id, prompt, reply, response, summary, user_query,
+       total_token_usage, response_time, time
+FROM mags_conversation_entries
+WHERE conversation_id = :conversation_id
+ORDER BY time ASC;
+```
+
+If you need the exact threaded order or related artifacts, get the ordered `entry_id`s from the graph first:
+
+```cypher
+MATCH (c:Artifact {type: 'Conversation', id: $conversationId})-[:HAS_ENTRY]->(start:Entry)
+MATCH path = (start)-[:NEXT*0..]->(e:Entry)
+RETURN e.entry_id AS entry_id, e.summary AS summary, e.timestamp AS timestamp
+ORDER BY e.timestamp ASC
+```
+
+…then fetch content from `mags_conversation_entries` by `entry_id`.
+
+### Example — an observation or reflection
+
+The graph `Memory` node gives you only `id`, `type`, `timeseries_id`, `checksum`. Fetch the content from TimeSeries:
+
+```sql
+SELECT memory_id, memory_type, summary, key_points, actionable_insights,
+       importance, surprise, confidence_score, total_token_usage, time
+FROM mags_memory_records
+WHERE memory_id = :memory_id;
+```
+
+### Example — a plan
+
+Graph holds the plan → task → action hierarchy with `timeseries_id` on each node; the PDDL and full task/action detail come from `mags_plan_artifacts`, `mags_plan_tasks`, and `mags_plan_actions` keyed by those ids.
+
+### Optional: REST access via PostgREST
+
+The TimescaleDB deployment ships with a [PostgREST](https://postgrest.org/) container that exposes an `api` schema over HTTP. **The `mags_*` tables live in the `public` schema and are not exposed by default.** To expose a read path, create a view in the `api` schema and grant access to the appropriate role:
+
+```sql
+CREATE VIEW api.conversation_entries AS
+SELECT entry_id, conversation_id, agent_id, prompt, reply, response, summary, time
+FROM public.mags_conversation_entries;
+
+GRANT SELECT ON api.conversation_entries TO webuser;
+```
+
+PostgREST then serves it:
+
+```
+GET /conversation_entries?conversation_id=eq.{conversationId}&order=time.asc
+```
+
+See the [TimescaleDB deployment README](../installation/docker/src/timescaledb/timescaledb_readme.md) for PostgREST setup, roles, and SSL.
+
+## Configuration
+
+TimeSeries connection settings live alongside the other database settings in the agent configuration:
+
+```json
+{
+  "timeseries": {
+    "type": "timescaledb",
+    "host": "localhost",
+    "port": 5432,
+    "database": "mags_timeseries",
+    "username": "postgres",
+    "password": "your_password",
+    "connectionPoolSize": 10,
+    "commandTimeout": 15,
+    "connectionTimeout": 15,
+    "sslMode": "Prefer"
+  }
+}
+```
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `type` | `timescaledb` | `timescaledb` or `influxdb3` |
+| `host` / `port` | `localhost` / `5432` | Database endpoint |
+| `database` | `mags_timeseries` | Database name |
+| `connectionPoolSize` | `10` | Maximum pooled connections |
+| `commandTimeout` | `15` | Command timeout (seconds) |
+| `connectionTimeout` | `15` | Connection timeout (seconds) |
+| `sslMode` | `Prefer` | `Disable` \| `Allow` \| `Prefer` \| `Require` \| `VerifyCA` \| `VerifyFull` |
+
+The schema (tables, hypertables, indexes, and the repair queue) is created automatically on startup via `InitializeSchemaAsync()`. Tables are created with `IF NOT EXISTS`, so startup is idempotent.
+
+## Storage Management
+
+MAGS deliberately **does not delete data automatically** — complete audit trails are required for decision provenance, forensic analysis, and compliance. Storage is managed with TimescaleDB features instead:
+
+- **Compression** (recommended) — compress older chunks for 90 %+ storage savings while keeping the data queryable. High-volume tables (memory, conversation, tool attempts/calls) compress after a few days; audit and SBOM after 90 days.
+- **Continuous aggregates** — pre-computed daily/hourly rollups for analytics, so dashboards don't scan raw data.
+- **Partitioning** — TimescaleDB partitions each hypertable by time automatically.
+- **Retention policies** — supported but **off by default**, because deletion breaks audit continuity. Only enable if you are legally required to delete data.
+
+The [TimescaleDB deployment README](../installation/docker/src/timescaledb/timescaledb_readme.md) contains the concrete compression, aggregate, retention, backup, and monitoring commands.
+
+## Related Documentation
+
+- [Memory Cycle](memory_cycle.md) — how observations, reflections, and plans flow through the stores
+- [Agent Messaging Protocol](../concepts/agent-messaging.md) — retrieving content after a message response
+- [Vector Database](vector_database.md) — the embedding store
+- [TimescaleDB Deployment](../installation/docker/src/timescaledb/timescaledb_readme.md) — installation, PostgREST, storage operations


### PR DESCRIPTION
## Summary

The docs still described the old **dual-store** model (Graph + Vector) with the graph database holding all agent content. The codebase now uses a **three-database hybrid architecture** where the **TimeSeries DB (TimescaleDB / InfluxDB 3) is the source of truth** and the graph holds only lightweight references (`id`, `timeseries_id`, `checksum`) plus relationships. This PR brings the documentation in line with the code.

Table names, column names, the `CreateMemoryCycle` signature, and the graph reference-node shape were all verified against the `xmags` source. Reconciled against current `main` (the earlier `feature-installation` base has since merged), so this is a clean 12-file delta.

## Changes

**New**
- `docs/technical-details/timeseries-storage.md` — canonical reference for the hybrid architecture, the Saga write path, the hybrid read/retrieval pattern (SQL + optional PostgREST), config, and storage management.

**Corrected — content now lives in TimeSeries, not the graph**
- `concepts/agent-messaging.md` — the old graph Cypher for retrieving conversations/observations/reflections/plans now returns `NULL`; replaced with TimeSeries SQL and a breaking-change note.
- `technical-details/memory_cycle.md` — architecture + sequence diagrams and the storage section rewritten to the three-DB model.
- `technical-details/memory_cycle_instantiation.md` — `CreateMemoryCycle` signature corrected (`neo4jConfig` → `graphDbConfig`, added `timeSeriesDbConfig` + optional `tripleStoreConfig`) plus init steps.

**Dual-database framing → hybrid three-database**
- `faq/technical.md` (databases Q + prerequisite)
- `installation.md` (adds the TimeSeries setup step; prerequisite was already present on main)
- `concepts/whymags.md`, `whymagspt2.md`, `howmagsusememory.md`, `architecture/README.md`
- `Glossary.md` — adds *TimeSeries Database*, *TimeSeries Database Type*, *DatabaseWriteSaga*; updates *Database Manager*
- `technical-details/README.md` — indexes the new doc

## Known follow-up (not in this PR)

The top-level `README.md` still embeds the old memory-cycle image (`docs/concepts/images/XMProORPAMemoryCycle.png`) showing the two-store model — needs a regenerated diagram, out of scope for a text PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)